### PR TITLE
Add server-side login and dynamic page list

### DIFF
--- a/BACKOFFICE_README.md
+++ b/BACKOFFICE_README.md
@@ -1,0 +1,13 @@
+# Backoffice Usage
+
+`backoffice/index.html` opens the administration interface.
+
+Default login password is `admin123`.
+
+## Features
+
+- **Login Required**: the server verifies your password and maintains a session.
+- **Page Editor**: pick a page from the list and toggle design mode to edit it directly in the browser, then click "저장" to save.
+- **공지 발송**: send an email to all addresses in `data/employees.csv`.
+
+These scripts remain simplified. Add proper user management and input validation for real deployments.

--- a/backoffice/auth.php
+++ b/backoffice/auth.php
@@ -1,0 +1,18 @@
+<?php
+session_start();
+$config = include __DIR__.'/config.php';
+
+if (isset($_POST['password'])) {
+    if (hash('sha256', $_POST['password']) === $config['password_hash']) {
+        $_SESSION['backoffice'] = true;
+        exit('OK');
+    } else {
+        http_response_code(401);
+        exit('Invalid');
+    }
+}
+
+if (isset($_GET['check'])) {
+    exit(isset($_SESSION['backoffice']) ? '1' : '0');
+}
+?>

--- a/backoffice/config.php
+++ b/backoffice/config.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'password_hash' => '240be518fabd2724ddb6f04eeb1da5967448d7e831c08c8fa822809f74c720a9' // sha256 of admin123
+];

--- a/backoffice/index.html
+++ b/backoffice/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>Backoffice</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="loginPanel">
+        <h2>관리자 로그인</h2>
+        <input type="password" id="password" placeholder="Password">
+        <button id="loginBtn">Login</button>
+    </div>
+    <div id="mainPanel" style="display:none;">
+        <nav>
+            <button data-view="editor">페이지 편집</button>
+            <button data-view="notify">공지 발송</button>
+        </nav>
+        <section id="editor" class="view" style="display:none;">
+            <h3>페이지 편집</h3>
+            <select id="pageSelect"></select>
+            <button id="loadPage">불러오기</button>
+            <button id="toggleDesign">디자인 모드</button>
+            <button id="savePage">저장</button>
+            <iframe id="pageFrame" style="width:100%;height:70vh;"></iframe>
+        </section>
+        <section id="notify" class="view" style="display:none;">
+            <h3>공지 발송</h3>
+            <input type="text" id="mailSubject" placeholder="제목">
+            <textarea id="mailMessage" placeholder="내용"></textarea>
+            <button id="sendMail">발송</button>
+            <div id="mailStatus"></div>
+        </section>
+    </div>
+    <script src="../js/jquery-3.6.0.min.js"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/backoffice/list_pages.php
+++ b/backoffice/list_pages.php
@@ -1,0 +1,21 @@
+<?php
+session_start();
+if (!isset($_SESSION['backoffice']) || $_SESSION['backoffice'] !== true) {
+    http_response_code(403);
+    exit('Unauthorized');
+}
+
+$pages = [];
+$dir = new RecursiveIteratorIterator(new RecursiveDirectoryIterator('..', FilesystemIterator::SKIP_DOTS));
+foreach ($dir as $file) {
+    if ($file->getFilename() === 'index.html') {
+        $path = substr($file->getPathname(), 3); // remove '../'
+        if (strpos($path, 'backoffice') === 0 || strpos($path, 'data') === 0) {
+            continue;
+        }
+        $pages[] = $path;
+    }
+}
+header('Content-Type: application/json');
+echo json_encode($pages);
+?>

--- a/backoffice/notify.php
+++ b/backoffice/notify.php
@@ -1,0 +1,21 @@
+<?php
+session_start();
+if (!isset($_SESSION['backoffice']) || $_SESSION['backoffice'] !== true) {
+    http_response_code(403);
+    exit('Unauthorized');
+}
+
+$subject = $_POST['subject'];
+$message = $_POST['message'];
+$employees = file('../data/employees.csv', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+$to = [];
+foreach ($employees as $emp) {
+    list($name, $email) = explode(',', $emp);
+    $to[] = $email;
+}
+$headers = "From: webmaster@example.com";
+foreach ($to as $email) {
+    mail($email, $subject, $message, $headers);
+}
+echo 'Mail sent to ' . count($to) . ' employees';
+?>

--- a/backoffice/save_page.php
+++ b/backoffice/save_page.php
@@ -1,0 +1,17 @@
+<?php
+session_start();
+if (!isset($_SESSION['backoffice']) || $_SESSION['backoffice'] !== true) {
+    http_response_code(403);
+    exit('Unauthorized');
+}
+
+$path = $_POST['path'];
+$content = $_POST['content'];
+$realBase = realpath('..');
+$realPath = realpath("../" . $path);
+if ($realPath === false || strpos($realPath, $realBase) !== 0) {
+    exit('Invalid path');
+}
+file_put_contents($realPath, $content);
+echo 'Saved';
+?>

--- a/backoffice/script.js
+++ b/backoffice/script.js
@@ -1,0 +1,58 @@
+$(function(){
+    $('#loginBtn').on('click', function(){
+        $.post('auth.php', {password: $('#password').val()}, function(res){
+            if(res === 'OK'){
+                $('#loginPanel').hide();
+                $('#mainPanel').show();
+                loadPageList();
+            }else{
+                alert('패스워드 오류');
+            }
+        });
+    });
+
+    $('nav button').on('click', function(){
+        var view = $(this).data('view');
+        $('.view').hide();
+        $('#' + view).show();
+    });
+
+    $('#loadPage').on('click', function(){
+        var path = $('#pageSelect').val();
+        $('#pageFrame').attr('src', path);
+    });
+
+    $('#toggleDesign').on('click', function(){
+        var frame = document.getElementById('pageFrame');
+        frame.contentDocument.designMode = frame.contentDocument.designMode === 'on' ? 'off' : 'on';
+    });
+
+    $('#savePage').on('click', function(){
+        var frame = document.getElementById('pageFrame');
+        var content = frame.contentDocument.documentElement.outerHTML;
+        $.post('save_page.php', {
+            path: $('#pageSelect').val(),
+            content: content
+        }, function(res){
+            alert(res);
+        });
+    });
+
+    $('#sendMail').on('click', function(){
+        $.post('notify.php', {
+            subject: $('#mailSubject').val(),
+            message: $('#mailMessage').val()
+        }, function(res){
+            $('#mailStatus').text(res);
+        });
+    });
+
+    function loadPageList(){
+        $.getJSON('list_pages.php', function(pages){
+            $('#pageSelect').empty();
+            pages.forEach(function(p){
+                $('#pageSelect').append('<option value="'+p+'">'+p+'</option>');
+            });
+        });
+    }
+});

--- a/backoffice/style.css
+++ b/backoffice/style.css
@@ -1,0 +1,4 @@
+body { font-family: Arial, sans-serif; margin: 0; padding: 20px; }
+nav { margin-bottom: 10px; }
+nav button { margin-right: 10px; }
+#pageFrame { border: 1px solid #ccc; }

--- a/data/employees.csv
+++ b/data/employees.csv
@@ -1,0 +1,2 @@
+홍길동,user1@example.com
+김철수,user2@example.com


### PR DESCRIPTION
## Summary
- enable session-based authentication using `auth.php`
- secure page save and notifications behind login
- dynamically list editable pages
- update backoffice README

## Testing
- ❌ `php -l backoffice/auth.php` (failed to run: `bash: php: command not found`)
- ❌ `php -l backoffice/save_page.php` (failed to run: `bash: php: command not found`)
- ❌ `php -l backoffice/notify.php` (failed to run: `bash: php: command not found`)
- ❌ `php -l backoffice/list_pages.php` (failed to run: `bash: php: command not found`)
- ❌ `php -l backoffice/config.php` (failed to run: `bash: php: command not found`)


------
https://chatgpt.com/codex/tasks/task_e_685378e7548883229729fe6493c6701d